### PR TITLE
ci: add test and lint workflows

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,35 @@
+name: Main
+on: push
+
+jobs:
+    test:
+        name: Test
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: Setup go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: "1.20"
+                  cache: false
+            - name: Build
+              run: "go build ./..."
+            - name: Test
+              run: "go test ./..."
+    lint:
+        name: Lint
+        runs-on: ubuntu-latest
+        steps:
+            - name: Checkout code
+              uses: actions/checkout@v3
+            - name: Setup go
+              uses: actions/setup-go@v4
+              with:
+                  go-version: "1.20"
+                  cache: false
+            - name: Lint
+              uses: golangci/golangci-lint-action@v3
+              with:
+                  version: v1.53
+                  args: --config=.golangci.yaml

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,122 @@
+output:
+  format: github-actions
+  print-issued-lines: true
+  print-linter-name: true
+  uniq-by-line: true
+  sort-results: true
+
+linters-settings:
+  gofmt:
+    simplify: true
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+severity:
+  case-sensitive: true
+
+linters:
+  enable-all: true
+  disable:
+  # TODO(https://github.com/nlnwa/go_container/issues/3): The following
+  # sub-linters should be evaluated if they are going to be enabled or not.
+    - asasalint
+    - asciicheck
+    - bidichk
+    - bodyclose
+    - containedctx
+    - contextcheck
+    - cyclop
+    - deadcode
+    - decorder
+    - depguard
+    - dogsled
+    - dupl
+    - dupword
+    - durationcheck
+    - errchkjson
+    - errname
+    - errorlint
+    - execinquery
+    - exhaustive
+    - exhaustivestruct
+    - exhaustruct
+    - exportloopref
+    - forbidigo
+    - forcetypeassert
+    - funlen
+    - gci
+    - ginkgolinter
+    - gocheckcompilerdirectives
+    - gochecknoglobals
+    - gochecknoinits
+    - gocognit
+    - goconst
+    - gocritic
+    - gocyclo
+    - godot
+    - godox
+    - goerr113
+    - gofumpt
+    - goheader
+    - goimports
+    - golint
+    - gomnd
+    - gomoddirectives
+    - gomodguard
+    - goprintffuncname
+    - gosec
+    - gosmopolitan
+    - grouper
+    - ifshort
+    - importas
+    - interfacebloat
+    - interfacer
+    - ireturn
+    - lll
+    - loggercheck
+    - maintidx
+    - makezero
+    - maligned
+    - mirror
+    - misspell
+    - musttag
+    - nakedret
+    - nestif
+    - nilerr
+    - nilnil
+    - nlreturn
+    - noctx
+    - nolintlint
+    - nonamedreturns
+    - nosnakecase
+    - nosprintfhostport
+    - paralleltest
+    - prealloc
+    - predeclared
+    - promlinter
+    - reassign
+    - revive
+    - rowserrcheck
+    - scopelint
+    - sqlclosecheck
+    - structcheck
+    - stylecheck
+    - tagalign
+    - tagliatelle
+    - tenv
+    - testableexamples
+    - testpackage
+    - thelper
+    - tparallel
+    - unconvert
+    - unparam
+    - usestdlibvars
+    - varcheck
+    - varnamelen
+    - wastedassign
+    - whitespace
+    - wrapcheck
+    - wsl
+    - zerologlint


### PR DESCRIPTION
This commit adds continuous integration capability to this repo, so tests can be run automatically when added.

`golangci-lint` seems to be the standard linter for `golang`, and this linter have already been used in several other repos so that is why it was chosen.

The sub-linters that are enabled are the by default enabled ones, as of version v1.53.3:

* `errcheck`
* `gosimple`
* `govet`
* `ineffassign`
* `staticcheck`
* `typecheck`
* `unused`

of the default disabled ones the following has been enabled, as of version v1.53.3:

* `gofmt`, to ensure all code has been formatted properly

An [issue](https://github.com/nlnwa/go_container/issues/3) has been introduced to deal with the remaining sub-linters.