### PR TITLE
ci: add continuous delivery workflows

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,48 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v[0-9]+.[0-9]+.[0-9]+**"
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build:
+    name: Create and release docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Extract metadata (tags, labels, version) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=ref,event=branch
+            type=ref,event=pr
+
+      - name: Log in to the container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3
+        with:
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Commit 060d043833410271e4005e982611d5c2c482ed0e added a basic CI workflow, while this commit adds a continuous delivery workflow to avoid having to manually release new containers.

To create a new package, you need two things:
* a PR ready to be merged to `main`
* a tag following [semver](https://semver.org/), for instance `v1.2.3-alpha` attributed to one of the commits in the PR.

When merged, a `docker` image will be built and uploaded to [GitHub Container Registry](https://github.com/features/packages).

Some of the meta data is unused, fetched by `docker/metadata-action`. Those fields are likely to be used in a real project so keeping them will likely reduce the overall congnitive load for developers dealing with multiple if the release workflows are as similar as possible.