### PR TITLE
docs: add bug and feature request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,0 +1,34 @@
+---
+name: Bug Report
+about: Create a bug report to help us improve
+labels: "bug"
+---
+
+**Bug Report**
+
+<!--
+A clear and concise description of what the bug is.
+-->
+
+**To Reproduce**
+
+```shell
+# A standalone program is preferred
+```
+
+**Expected Behavior**
+
+<!--
+What was the expected behavior of the program? Was it supposed to exit without errors or
+do something else?
+-->
+
+**Actual Behavior**
+
+<!--
+What actually happened? Please add any relevant output in this section
+-->
+
+**Your Environment**
+
+<!-- This could include, operating system, version of the software, etc-->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Propose a new feature
+labels: "feature"
+---
+
+**Motivation**
+
+<!--
+Please explain the rationale for adding the feature. Do you have a scenario that illustrates your needs?
+-->
+
+**Feature**
+
+<!--
+A short description of the feature.
+-->


### PR DESCRIPTION
After testing this in my private repo, this is how it looks like:
![image](https://github.com/nlnwa/go_container/assets/22957880/9f511c99-7513-43b9-985a-7fccbaa9f077)

![image](https://github.com/nlnwa/go_container/assets/22957880/23669bf2-bee2-4260-a6a7-4bf3d97ae858)

![image](https://github.com/nlnwa/go_container/assets/22957880/304ca9bd-0eb5-4803-b6f1-59d68758d1e0)

![image](https://github.com/nlnwa/go_container/assets/22957880/abc6969a-6537-432a-96ce-be364030c9ad)

![image](https://github.com/nlnwa/go_container/assets/22957880/b05b8729-49b8-4bce-a33b-7f5212b3a538)
