### PR TITLE
ci: add `dependabot` config

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,31 @@
+version: 2
+updates:
+    - package-ecosystem: "gomod"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build(deps)"
+          include: "scope"
+
+    - package-ecosystem: "docker"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build(deps)"
+          include: "scope"
+
+    - package-ecosystem: "github-actions"
+      directory: "/"
+      schedule:
+          interval: "weekly"
+      labels:
+          - "dependencies"
+      commit-message:
+          prefix: "build(deps)"
+          include: "scope"


### PR DESCRIPTION
This commit adds a config file that will ensure `docker` and `golang` dependencies will stay up to date.

Commit messages generated by `dependabot` will be prefixed with `build(deps)` to follow the conventional commits commit message convention.