### PR TITLE
ci: change `dependabot` commit message settings

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -7,7 +7,7 @@ updates:
       labels:
           - "dependencies"
       commit-message:
-          prefix: "build(deps)"
+          prefix: "build"
           include: "scope"
 
     - package-ecosystem: "docker"
@@ -17,7 +17,7 @@ updates:
       labels:
           - "dependencies"
       commit-message:
-          prefix: "build(deps)"
+          prefix: "build"
           include: "scope"
 
     - package-ecosystem: "github-actions"
@@ -27,5 +27,5 @@ updates:
       labels:
           - "dependencies"
       commit-message:
-          prefix: "build(deps)"
+          prefix: "build"
           include: "scope"


### PR DESCRIPTION
Previously `dependabot` created a commit message with the title `build(deps)(deps): bump docker/build-push-action from 3 to 4`.

To avoid the duplicate `(deps)` part, the commit message prefix has now been limited to just `build` from `build(deps)`