### PR TITLE
refactor: use minimal docker image as run-stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ COPY . .
 
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -o /ping-server
 
-FROM golang:1.20 AS run-stage
+FROM gcr.io/distroless/base-debian11 AS run-stage
 
 WORKDIR /run
 


### PR DESCRIPTION
Using a minimal image as a base for the `run`-stage in the docker file ensures that there would be minimal dependencies between the `build` and the `run`.

By using `distroless` images from
https://github.com/GoogleContainerTools/distroless we run the code in a very minimal image.

`base` seems more restrictive than `static`, so setting it to `base` seems like a good default.